### PR TITLE
adding isSecret method to mask values

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   general-settings-json: #id of input
     description: 'General configuration settings using dictionary syntax - Key Value pairs'
     required: false
+  mask-inputs: 
+    description: 'Set it to false if you want to provide input jsons as plain text/you do not want input json values to be masked. This will apply to all input jsons. Default is true'
+    required: false
+    default: true
 outputs:
   webapp-url: # id of output
     description: 'URL to work with your webapp'

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -1,0 +1,30 @@
+"use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(require("@actions/core"));
+class Utils {
+    static validateSettings(customSettings, maskInputs) {
+        try {
+            var customParsedSettings = JSON.parse(customSettings);
+            if (maskInputs !== "false") {
+                Utils.maskValues(customParsedSettings);
+            }
+            return customParsedSettings;
+        }
+        catch (error) {
+            throw new Error('Given Settings object is not a valid JSON');
+        }
+    }
+    static maskValues(jsonContent) {
+        for (let i = 0; i < Object.keys(jsonContent).length; i++) {
+            core.setSecret(jsonContent[i].value);
+        }
+    }
+}
+exports.Utils = Utils;

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -12,7 +12,7 @@ class Utils {
     static validateSettings(customSettings, maskInputs) {
         try {
             var customParsedSettings = JSON.parse(customSettings);
-            if (!!maskInputs && maskInputs !== "false") {
+            if (maskInputs !== "false") {
                 Utils.maskValues(customParsedSettings);
             }
             return customParsedSettings;

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -12,7 +12,7 @@ class Utils {
     static validateSettings(customSettings, maskInputs) {
         try {
             var customParsedSettings = JSON.parse(customSettings);
-            if (maskInputs !== "false") {
+            if (!!maskInputs && maskInputs !== "false") {
                 Utils.maskValues(customParsedSettings);
             }
             return customParsedSettings;

--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,7 @@ function main() {
                 yield appServiceUtility.updateConnectionStrings(customConnectionStrings);
             }
             if (ConfigurationSettings) {
-                let customConfigurationSettings = Utils_1.Utils.validateSettings(ConfigurationSettings, maskInputs);
+                let customConfigurationSettings = Utils_1.Utils.validateSettings(ConfigurationSettings);
                 yield appServiceUtility.updateConfigurationSettings(customConfigurationSettings);
             }
             applicationURL = yield appServiceUtility.getApplicationURL();

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,6 +18,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const crypto = __importStar(require("crypto"));
+const Utils_1 = require("./Utils");
 const azure_app_service_1 = require("azure-actions-appservice-rest/lib/Arm/azure-app-service");
 const AzureAppServiceUtility_1 = require("azure-actions-appservice-rest/lib/Utilities/AzureAppServiceUtility");
 const AzureResourceFilterUtility_1 = require("azure-actions-appservice-rest/lib/Utilities/AzureResourceFilterUtility");
@@ -36,10 +37,12 @@ function main() {
             let AppSettings = core.getInput('app-settings-json', { required: false });
             let ConnectionStrings = core.getInput('connection-strings-json', { required: false });
             let ConfigurationSettings = core.getInput('general-settings-json', { required: false });
+            const maskInputs = core.getInput('mask-inputs', { required: false });
             let applicationURL;
             if (!AppSettings && !ConnectionStrings && !ConfigurationSettings) {
                 throw Error('App Service Settings is not enabled. Please provide one of the following : App Settings or General Settings or Connection Strings.');
             }
+            // Validating parsed inputs
             let endpoint = yield AuthorizationHandlerFactory_1.getHandler();
             console.log("Got service connection details for Azure App Service: " + webAppName);
             let appDetails = yield AzureResourceFilterUtility_1.AzureResourceFilterUtility.getAppDetails(endpoint, webAppName);
@@ -48,15 +51,15 @@ function main() {
             let appService = new azure_app_service_1.AzureAppService(endpoint, resourceGroupName, webAppName, slotName);
             let appServiceUtility = new AzureAppServiceUtility_1.AzureAppServiceUtility(appService);
             if (AppSettings) {
-                let customApplicationSettings = validateSettings(AppSettings);
+                let customApplicationSettings = Utils_1.Utils.validateSettings(AppSettings, maskInputs);
                 yield appServiceUtility.updateAndMonitorAppSettings(customApplicationSettings, null);
             }
             if (ConnectionStrings) {
-                let customConnectionStrings = validateSettings(ConnectionStrings);
+                let customConnectionStrings = Utils_1.Utils.validateSettings(ConnectionStrings, maskInputs);
                 yield appServiceUtility.updateConnectionStrings(customConnectionStrings);
             }
             if (ConfigurationSettings) {
-                let customConfigurationSettings = validateSettings(ConfigurationSettings);
+                let customConfigurationSettings = Utils_1.Utils.validateSettings(ConfigurationSettings, maskInputs);
                 yield appServiceUtility.updateConfigurationSettings(customConfigurationSettings);
             }
             applicationURL = yield appServiceUtility.getApplicationURL();
@@ -73,20 +76,4 @@ function main() {
     });
 }
 exports.main = main;
-function validateSettings(customSettings) {
-    try {
-        var customParsedSettings = JSON.parse(customSettings);
-        maskValues(customParsedSettings);
-        return customParsedSettings;
-    }
-    catch (error) {
-        throw new Error('Given Settings object is not a valid JSON');
-    }
-}
-exports.validateSettings = validateSettings;
-function maskValues(jsonContent) {
-    for (let i = 0; i < Object.keys(jsonContent).length; i++) {
-        core.setSecret(jsonContent[i].value);
-    }
-}
 main();

--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,7 @@ function main() {
                 yield appServiceUtility.updateConnectionStrings(customConnectionStrings);
             }
             if (ConfigurationSettings) {
-                let customConfigurationSettings = Utils_1.Utils.validateSettings(ConfigurationSettings);
+                let customConfigurationSettings = Utils_1.Utils.validateSettings(ConfigurationSettings, maskInputs);
                 yield appServiceUtility.updateConfigurationSettings(customConfigurationSettings);
             }
             applicationURL = yield appServiceUtility.getApplicationURL();

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,7 +37,7 @@ function main() {
             let AppSettings = core.getInput('app-settings-json', { required: false });
             let ConnectionStrings = core.getInput('connection-strings-json', { required: false });
             let ConfigurationSettings = core.getInput('general-settings-json', { required: false });
-            const maskInputs = core.getInput('mask-inputs', { required: false });
+            const maskInputs = core.getInput('mask-inputs', { required: false }).toLowerCase();
             let applicationURL;
             if (!AppSettings && !ConnectionStrings && !ConfigurationSettings) {
                 throw Error('App Service Settings is not enabled. Please provide one of the following : App Settings or General Settings or Connection Strings.');

--- a/src/Tests/azureAppServiceSettings.test.ts
+++ b/src/Tests/azureAppServiceSettings.test.ts
@@ -36,6 +36,10 @@ var jsonObject = {
 
 describe('Test Azure App Service Settings', () => {
 
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     afterEach(() => {
         jest.restoreAllMocks();
     })
@@ -110,7 +114,7 @@ describe('Test Azure App Service Settings', () => {
             console.log(e);
         }
 
-        expect(getInputSpy).toHaveBeenCalledTimes(5);
+        expect(getInputSpy).toHaveBeenCalledTimes(6);
         expect(appDetails).toHaveBeenCalled();
         expect(getApplicationURLSpy).toHaveBeenCalled();
         expect(validateSettingsSpy).toHaveBeenCalled();

--- a/src/Tests/azureAppServiceSettings.test.ts
+++ b/src/Tests/azureAppServiceSettings.test.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
-import {main, validateSettings} from "../main";
+import { main } from "../main";
+import { Utils } from  "../Utils";
 
 import { AzureResourceFilterUtility } from 'azure-actions-appservice-rest/lib/Utilities/AzureResourceFilterUtility';
 import { AzureAppServiceUtility } from 'azure-actions-appservice-rest/lib/Utilities/AzureAppServiceUtility';
@@ -14,6 +15,7 @@ jest.mock('azure-actions-appservice-rest/lib/Utilities/AzureAppServiceUtility');
 var jsonObject = {
     'app-name': 'MOCK_APP_NAME',
     'resource-group-name' : 'MOCK_RESOURCE_GROUP',
+    'mask-inputs': 'false',
     'app-kind' : 'MOCK_APP_KIND',
     'app-settings-json': `[
         {
@@ -62,7 +64,7 @@ describe('Test Azure App Service Settings', () => {
             console.log(e);
         }
 
-        expect(getInputSpy).toHaveBeenCalledTimes(5);
+        expect(getInputSpy).toHaveBeenCalledTimes(6);
         expect(appDetails).toHaveBeenCalled();
         expect(getApplicationURLSpy).toHaveBeenCalled();
     });
@@ -79,6 +81,40 @@ describe('Test Azure App Service Settings', () => {
 
         expect(validateSettings).toHaveBeenCalledTimes(2);
         expect(validateSettings).toHaveReturnedTimes(2);
-    })
+    });
+
+    it("do not set inputs as secrets if mask-inputs is false", async () => {
+        
+        let getInputSpy = jest.spyOn(core, 'getInput').mockImplementation((name, options) => {
+            switch(name) {
+                case 'app-name': return jsonObject['app-name'];
+                case 'connection-strings-json' : return jsonObject['connection-strings-json'];
+                case 'mask-inputs': return jsonObject['mask-inputs'];
+            }
+            return '';
+        });
+
+        let appDetails = jest.spyOn(AzureResourceFilterUtility, 'getAppDetails').mockResolvedValue({
+            resourceGroupName: jsonObject['resource-group-name'],
+            kind: jsonObject['app-kind']
+        });
+
+        let getApplicationURLSpy = jest.spyOn(AzureAppServiceUtility.prototype, 'getApplicationURL').mockResolvedValue('http://testurl');
+        let validateSettingsSpy = jest.spyOn(Utils, 'validateSettings');
+        let maskValuesSpy = jest.spyOn(Utils, 'maskValues');
+
+        try {
+            await main();
+        }
+        catch(e) {
+            console.log(e);
+        }
+
+        expect(getInputSpy).toHaveBeenCalledTimes(5);
+        expect(appDetails).toHaveBeenCalled();
+        expect(getApplicationURLSpy).toHaveBeenCalled();
+        expect(validateSettingsSpy).toHaveBeenCalled();
+        expect(maskValuesSpy).not.toHaveBeenCalled();
+    });
 
 });

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,10 +1,10 @@
 import * as core from '@actions/core';
 
 export class Utils {
-    static validateSettings(customSettings: string, maskInputs?: string) {
+    static validateSettings(customSettings: string, maskInputs: string) {
         try {
             var customParsedSettings = JSON.parse(customSettings);
-            if (!!maskInputs && maskInputs !== "false") {
+            if (maskInputs !== "false") {
                 Utils.maskValues(customParsedSettings);
             }
             return customParsedSettings;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,0 +1,23 @@
+import * as core from '@actions/core';
+
+export class Utils {
+    static validateSettings(customSettings: string, maskInputs: string) {
+        try {
+            var customParsedSettings = JSON.parse(customSettings);
+            if (maskInputs !== "false") {
+                Utils.maskValues(customParsedSettings);
+            }
+            return customParsedSettings;
+        }
+        catch (error) {
+            throw new Error('Given Settings object is not a valid JSON');
+        }
+    }
+    
+    static maskValues(jsonContent: any) {
+        for(let i = 0; i< Object.keys(jsonContent).length; i++) {
+            core.setSecret(jsonContent[i].value);
+        }
+    }
+
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,10 +1,10 @@
 import * as core from '@actions/core';
 
 export class Utils {
-    static validateSettings(customSettings: string, maskInputs: string) {
+    static validateSettings(customSettings: string, maskInputs?: string) {
         try {
             var customParsedSettings = JSON.parse(customSettings);
-            if (maskInputs !== "false") {
+            if (!!maskInputs && maskInputs !== "false") {
                 Utils.maskValues(customParsedSettings);
             }
             return customParsedSettings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ export async function main() {
         }
         
         if(ConfigurationSettings) {
-            let customConfigurationSettings = Utils.validateSettings(ConfigurationSettings);
+            let customConfigurationSettings = Utils.validateSettings(ConfigurationSettings, maskInputs);
             await appServiceUtility.updateConfigurationSettings(customConfigurationSettings);
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ export async function main() {
         let AppSettings: string = core.getInput('app-settings-json', {required: false});
         let ConnectionStrings: string = core.getInput('connection-strings-json', {required: false});
         let ConfigurationSettings: string = core.getInput('general-settings-json', {required: false});
-        const maskInputs: string = core.getInput('mask-inputs', { required: false });
+        const maskInputs: string = core.getInput('mask-inputs', { required: false }).toLowerCase();
         let applicationURL: string;
 
         if(!AppSettings && !ConnectionStrings && !ConfigurationSettings) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ export async function main() {
         }
         
         if(ConfigurationSettings) {
-            let customConfigurationSettings = Utils.validateSettings(ConfigurationSettings, maskInputs);
+            let customConfigurationSettings = Utils.validateSettings(ConfigurationSettings);
             await appServiceUtility.updateConfigurationSettings(customConfigurationSettings);
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
 import * as crypto from "crypto";
 
+import { Utils } from  "./Utils";
 import { AzureAppService } from 'azure-actions-appservice-rest/lib/Arm/azure-app-service';
 import { AzureAppServiceUtility } from 'azure-actions-appservice-rest/lib/Utilities/AzureAppServiceUtility';
 import { AzureResourceFilterUtility } from 'azure-actions-appservice-rest/lib/Utilities/AzureResourceFilterUtility';
@@ -23,12 +24,14 @@ export async function main() {
         let AppSettings: string = core.getInput('app-settings-json', {required: false});
         let ConnectionStrings: string = core.getInput('connection-strings-json', {required: false});
         let ConfigurationSettings: string = core.getInput('general-settings-json', {required: false});
+        const maskInputs: string = core.getInput('mask-inputs', { required: false });
         let applicationURL: string;
 
         if(!AppSettings && !ConnectionStrings && !ConfigurationSettings) {
             throw Error('App Service Settings is not enabled. Please provide one of the following : App Settings or General Settings or Connection Strings.');
         }
-        
+
+        // Validating parsed inputs
         let endpoint: IAuthorizationHandler = await getHandler();
         console.log("Got service connection details for Azure App Service: " + webAppName);
 
@@ -40,17 +43,17 @@ export async function main() {
         let appServiceUtility: AzureAppServiceUtility = new AzureAppServiceUtility(appService);
 
         if(AppSettings) {
-            let customApplicationSettings = validateSettings(AppSettings);
+            let customApplicationSettings = Utils.validateSettings(AppSettings, maskInputs);
             await appServiceUtility.updateAndMonitorAppSettings(customApplicationSettings, null);
         }
 
         if(ConnectionStrings) {
-            let customConnectionStrings = validateSettings(ConnectionStrings);
+            let customConnectionStrings = Utils.validateSettings(ConnectionStrings, maskInputs);
             await appServiceUtility.updateConnectionStrings(customConnectionStrings);
         }
         
         if(ConfigurationSettings) {
-            let customConfigurationSettings = validateSettings(ConfigurationSettings);
+            let customConfigurationSettings = Utils.validateSettings(ConfigurationSettings, maskInputs);
             await appServiceUtility.updateConfigurationSettings(customConfigurationSettings);
         }
 
@@ -64,23 +67,6 @@ export async function main() {
     finally {
         // Reset AZURE_HTTP_USER_AGENT
         core.exportVariable('AZURE_HTTP_USER_AGENT', prefix);
-    }
-}
-
-export function validateSettings(customSettings: string) {
-    try {
-        var customParsedSettings = JSON.parse(customSettings);
-        maskValues(customParsedSettings);
-        return customParsedSettings;
-    }
-    catch (error) {
-        throw new Error('Given Settings object is not a valid JSON');
-    }
-}
-
-function maskValues(jsonContent) {
-    for(let i = 0; i< Object.keys(jsonContent).length; i++) {
-        core.setSecret(jsonContent[i].value);
     }
 }
 


### PR DESCRIPTION
#16 
Adding code changes to avoid masking input which is not provided as secrets. Code changes will address the issue where if the input json is given as plain text, action does not add it as secret so that the values in settings are not masked by actions platform.

Currently the inputs "app-settings-json" and "connection-strings-json" are masked. Individual key value pairs are masked. 
Input "general-settings-json" is not masked.

If the user gives "app-settings-json" and "connection-strings-json" as plain text and not as secrets, with this change we expect the json to have the following structure for not masking:

```
app-settings-json': `[
        {
            "name": "key2",
            "value": "value",
            "slotSetting": true
        }, 
        {
            "secret": false
        }
    ]

```
If "app-settings-json" and "connection-strings-json" have { "secret": false }, action will not mask the input json. Otherwise we will mask all the values in "app-settings-json" and "connection-strings-json".

@N-Usha Please let me know if "general-settings-json" input should also be masked. Currently action does not mask the general-settings-json or the its individual key-value pairs.
